### PR TITLE
move BatchTest to Inventory directory

### DIFF
--- a/src/test/java/medistock/inventory/BatchTest.java
+++ b/src/test/java/medistock/inventory/BatchTest.java
@@ -1,7 +1,4 @@
-package medistock.batch;
-
-
-import medistock.inventory.Inventory;
+package medistock.inventory;
 
 import medistock.exception.MediStockException;
 import medistock.parser.Parser;
@@ -9,7 +6,6 @@ import medistock.ui.Ui;
 import org.junit.jupiter.api.Test;
 
 import medistock.command.BatchCommand;
-import medistock.inventory.InventoryItem;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;


### PR DESCRIPTION
Move BatchTest to test/java/medistock/inventory directory, to organise codebase. 