### PR TITLE
Fix/fix p ed bugs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -76,18 +76,21 @@ The created item does not contain any batches yet; stock is added later through 
 1. Parses the user input to extract the item name, unit, and minimum threshold.
 2. Validates that `n/`, `u/`, and `min/` are present and that they appear in the correct order.
 3. Validates that name, unit, and minimum threshold are not empty.
-4. Parses the minimum threshold as a positive integer.
-5. Creates a `CreateCommand` with the validated values.
-6. Creates a new `InventoryItem` with the specified metadata and no batches, then calls `inventory.addItem(item)` to add it to the inventory.
-7. `inventory.addItem(item)` checks that another item with the same normalized name does not already exist.
-8. Calls `storage.saveToFile(item)` to append the new item to storage.
-9. Calls `ui.printCreate(name, unit, minimumThreshold)` to display the created item details.
-10. Records the creation in the command history.
+4. Validates that the name contains a drug name and does not contain a negative dosage value.
+5. Parses the minimum threshold as a positive integer.
+6. Creates a `CreateCommand` with the validated values.
+7. Creates a new `InventoryItem` with the specified metadata and no batches, then calls `inventory.addItem(item)` to add it to the inventory.
+8. `inventory.addItem(item)` checks that another item with the same normalized name does not already exist.
+9. Calls `storage.saveToFile(item)` to append the new item to storage.
+10. Calls `ui.printCreate(name, unit, minimumThreshold)` to display the created item details.
+11. Records the creation in the command history.
 
 **Failure cases & messages:**
 - If `n/`, `u/`, or `min/` is missing: "Invalid create format. Format: create n/NAME u/UNIT min/THRESHOLD"
 - If the argument order is invalid: "Use create format: Format: create n/NAME u/UNIT min/THRESHOLD"
 - If name, unit, or minimum threshold is empty: "Name, unit, and minimum threshold must not be empty."
+- If the name does not include a drug name: "Medication name must include a drug name."
+- If the name includes a negative dosage value: "Medication name must not include a negative dosage."
 - If the minimum threshold is not a valid number: "Minimum threshold must be a valid number."
 - If the minimum threshold is zero or negative: "Minimum threshold must be greater than 0."
 - If the item already exists in inventory: "Product already exists: \<name\>"

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -23,6 +23,10 @@ import java.time.format.DateTimeParseException;
  * Parses user input and converts it into executable commands.
  */
 public class Parser {
+    private static final String DOSAGE_UNITS = "mcg|mg|g|kg|ml|l|iu|units?|tablets?|capsules?";
+    private static final String DOSAGE_PATTERN = "\\b\\d+(?:\\.\\d+)?\\s*(?:" + DOSAGE_UNITS + ")\\b";
+    private static final String DOSAGE_UNIT_PATTERN = "\\b(?:" + DOSAGE_UNITS + ")\\b";
+
     public static Command parseCommand(String input) throws MediStockException {
         String text = input.trim();
 
@@ -85,6 +89,14 @@ public class Parser {
      */
     private static String getMinimum(String text, int minIndex) {
         return text.substring(minIndex + 4).trim();
+    }
+
+    private static boolean hasDrugName(String name) {
+        String textWithoutDosage = name.toLowerCase()
+                .replaceAll(DOSAGE_PATTERN, " ")
+                .replaceAll(DOSAGE_UNIT_PATTERN, " ");
+
+        return textWithoutDosage.matches(".*[a-z].*");
     }
 
     private static int getNextIndex(String text, int currentIndex, int... indexes) {
@@ -177,6 +189,10 @@ public class Parser {
 
         if (name.isEmpty() || unit.isEmpty() || minText.isEmpty()) {
             throw new MediStockException("Name, unit, and minimum threshold must not be empty.");
+        }
+
+        if (!hasDrugName(name)) {
+            throw new MediStockException("Medication name must include a drug name.");
         }
 
         int min;

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -25,6 +25,8 @@ import java.time.format.DateTimeParseException;
 public class Parser {
     private static final String DOSAGE_UNITS = "mcg|mg|g|kg|ml|l|iu|units?|tablets?|capsules?";
     private static final String DOSAGE_PATTERN = "\\b\\d+(?:\\.\\d+)?\\s*(?:" + DOSAGE_UNITS + ")\\b";
+    private static final String NEGATIVE_DOSAGE_PATTERN =
+            "(^|\\s)-\\d+(?:\\.\\d+)?\\s*(?:" + DOSAGE_UNITS + ")\\b";
     private static final String DOSAGE_UNIT_PATTERN = "\\b(?:" + DOSAGE_UNITS + ")\\b";
 
     public static Command parseCommand(String input) throws MediStockException {
@@ -97,6 +99,10 @@ public class Parser {
                 .replaceAll(DOSAGE_UNIT_PATTERN, " ");
 
         return textWithoutDosage.matches(".*[a-z].*");
+    }
+
+    private static boolean hasNegativeDosage(String name) {
+        return name.toLowerCase().matches(".*" + NEGATIVE_DOSAGE_PATTERN + ".*");
     }
 
     private static int getNextIndex(String text, int currentIndex, int... indexes) {
@@ -193,6 +199,10 @@ public class Parser {
 
         if (!hasDrugName(name)) {
             throw new MediStockException("Medication name must include a drug name.");
+        }
+
+        if (hasNegativeDosage(name)) {
+            throw new MediStockException("Medication must not include a negative dosage.");
         }
 
         int min;

--- a/src/test/java/medistock/parser/CreateParserTest.java
+++ b/src/test/java/medistock/parser/CreateParserTest.java
@@ -59,6 +59,14 @@ public class CreateParserTest {
     }
 
     @Test
+    void parseCommand_dosageOnlyName_throwsException() {
+        String input = "create n/ 100mg u/Tablets min/10";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
     void parseCommand_emptyUnit_throwsException() {
         String input = "create n/Aspirin u/ min/10";
 

--- a/src/test/java/medistock/parser/CreateParserTest.java
+++ b/src/test/java/medistock/parser/CreateParserTest.java
@@ -19,6 +19,14 @@ public class CreateParserTest {
     }
 
     @Test
+    void parseCommand_validCreateWithPositiveDosage_returnsCreateCommand() throws MediStockException {
+        String input = "create n/Paracetamol 500mg u/Tablets min/10";
+
+        Command command = Parser.parseCommand(input);
+        assertInstanceOf(CreateCommand.class, command);
+    }
+
+    @Test
     void parseCommand_missingNameTag_throwsException() {
         String input = "create u/Tablets min/10";
 
@@ -69,6 +77,14 @@ public class CreateParserTest {
     @Test
     void parseCommand_negativeDosageInName_throwsException() {
         String input = "create n/Paracetamol -100mg u/Tablets min/200";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_spacedNegativeDosageInName_throwsException() {
+        String input = "create n/Paracetamol -100 mg u/Tablets min/200";
 
         assertThrows(MediStockException.class,
                 () -> Parser.parseCommand(input));

--- a/src/test/java/medistock/parser/CreateParserTest.java
+++ b/src/test/java/medistock/parser/CreateParserTest.java
@@ -67,6 +67,14 @@ public class CreateParserTest {
     }
 
     @Test
+    void parseCommand_negativeDosageInName_throwsException() {
+        String input = "create n/Paracetamol -100mg u/Tablets min/200";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
     void parseCommand_emptyUnit_throwsException() {
         String input = "create n/Aspirin u/ min/10";
 


### PR DESCRIPTION
The create command now checks for invalid inputs. 

Rejects dosage-only names such as 100mg
Rejects negative dosage values in medication names such as Paracetamol -100mg
Adds parser regression tests for valid and invalid dosage cases
Updates the Developer Guide with the new create validation behavior

Addressed Issue #113 #114 


