### PR TITLE
Fix edit command accepting invalid edits and update DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -119,11 +119,12 @@ Finds the specified item using its current name, applies the requested updates, 
 1. Parses the user input to extract the old item name and the fields to update.
 2. Validates that `o/` is present and that at least one of `n/`, `u/`, or `min/` is provided.
 3. Calls `inventory.editItem(...)` to retrieve the current `InventoryItem` and determine the updated values.
-4. If a new name is provided, checks that it does not conflict with another existing item in the inventory.
-5. Creates an updated `InventoryItem` with the new metadata while preserving the existing batches, then replaces the old item entry in the inventory.
-6. Calls `storage.saveToFile(inventory)` to persist the updated inventory.
-7. Calls `ui.printEdit(oldName, updatedItem)` to display the updated item details.
-8. Records the edit in the command history.
+4. Checks that at least one resolved field value differs from the current item.
+5. If a new name is provided, checks that it does not conflict with another existing item in the inventory.
+6. Creates an updated `InventoryItem` with the new metadata while preserving the existing batches, then replaces the old item entry in the inventory.
+7. Calls `storage.saveToFile(inventory)` to persist the updated inventory.
+8. Calls `ui.printEdit(oldName, updatedItem)` to display the updated item details.
+9. Records the edit in the command history.
 
 **Failure cases & messages:**
 - If `o/` is missing: "Invalid edit format. Format: edit o/OLD_NAME [n/NEW_NAME] [u/NEW_UNIT] [min/NEW_THRESHOLD]"
@@ -136,6 +137,7 @@ Finds the specified item using its current name, applies the requested updates, 
 - If the new minimum threshold is not a valid number: "New minimum threshold must be a valid number."
 - If the new minimum threshold is zero or negative: "New minimum threshold must be greater than 0."
 - If the item does not exist in inventory: "Product not found: \<old_name\>"
+- If all provided values match the current item: "No changes made to product: \<old_name\>"
 - If the new name already exists in inventory: "Product already exists: \<new_name\>"
 
 **Logging:**

--- a/src/main/java/medistock/inventory/Inventory.java
+++ b/src/main/java/medistock/inventory/Inventory.java
@@ -117,6 +117,12 @@ public class Inventory {
         int updatedMinimumThreshold = newMinimumThreshold == null
                 ? currentItem.getMinimumThreshold() : newMinimumThreshold;
 
+        if (currentItem.getName().equals(updatedName)
+                && currentItem.getUnit().equals(updatedUnit)
+                && currentItem.getMinimumThreshold() == updatedMinimumThreshold) {
+            throw new MediStockException("No changes made to product: " + currentItem.getName());
+        }
+
         String oldKey = normalizeName(currentItem.getName());
         String newKey = normalizeName(updatedName);
 

--- a/src/test/java/medistock/command/EditCommandTest.java
+++ b/src/test/java/medistock/command/EditCommandTest.java
@@ -121,6 +121,25 @@ public class EditCommandTest {
     }
 
     @Test
+    void execute_noChanges_throwsExceptionAndDoesNotLogHistory() throws MediStockException {
+        Inventory inventory = new Inventory();
+        Ui ui = new Ui();
+        Storage storage = new Storage(tempDir.resolve("Inventory.txt"));
+        List<String> histories = new ArrayList<>();
+        InventoryItem item = new InventoryItem("Aspirin", "Tablets", 10);
+        inventory.addItem(item);
+
+        EditCommand command = new EditCommand("Aspirin", "Aspirin", "Tablets", 10);
+
+        assertThrows(MediStockException.class,
+                () -> command.execute(inventory, ui, storage, histories));
+        InventoryItem unchangedItem = inventory.getItem("Aspirin");
+        assertEquals("Tablets", unchangedItem.getUnit());
+        assertEquals(10, unchangedItem.getMinimumThreshold());
+        assertEquals(0, histories.size());
+    }
+
+    @Test
     void execute_renameToSameNormalizedName_succeeds() throws MediStockException {
         Inventory inventory = new Inventory();
         Ui ui = new Ui();

--- a/src/test/java/medistock/command/EditCommandTest.java
+++ b/src/test/java/medistock/command/EditCommandTest.java
@@ -140,6 +140,25 @@ public class EditCommandTest {
     }
 
     @Test
+    void execute_sameUnitOnly_throwsExceptionAndDoesNotLogHistory() throws MediStockException {
+        Inventory inventory = new Inventory();
+        Ui ui = new Ui();
+        Storage storage = new Storage(tempDir.resolve("Inventory.txt"));
+        List<String> histories = new ArrayList<>();
+        InventoryItem item = new InventoryItem("Aspirin", "Tablets", 10);
+        inventory.addItem(item);
+
+        EditCommand command = new EditCommand("Aspirin", null, "Tablets", null);
+
+        assertThrows(MediStockException.class,
+                () -> command.execute(inventory, ui, storage, histories));
+        InventoryItem unchangedItem = inventory.getItem("Aspirin");
+        assertEquals("Tablets", unchangedItem.getUnit());
+        assertEquals(10, unchangedItem.getMinimumThreshold());
+        assertEquals(0, histories.size());
+    }
+
+    @Test
     void execute_renameToSameNormalizedName_succeeds() throws MediStockException {
         Inventory inventory = new Inventory();
         Ui ui = new Ui();


### PR DESCRIPTION
Rejects no-op edit commands where the provided values match the existing item. This prevents repeated unchanged edits from overwriting inventory data or adding duplicate history entries, and updates the Developer Guide with the new behavior.
