### PR TITLE
Fix ped bugs - add error message for bare commands handling 

### DIFF
--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -32,7 +32,7 @@ public class Parser {
     public static Command parseCommand(String input) throws MediStockException {
         String text = input.trim();
 
-        if (text.startsWith("create ")) {
+        if (isCommandInput(text, "create")) {
             return prepareCreate(text);
         } else if (text.startsWith("edit ")) {
             return prepareEdit(text);
@@ -62,6 +62,10 @@ public class Parser {
                     + "  - Type <help> to see all available command formats."
                     + "  - Type <list> to view the current inventory state.");
         }
+    }
+
+    private static boolean isCommandInput(String text, String commandWord) {
+        return text.equals(commandWord) || text.startsWith(commandWord + " ");
     }
 
     /**

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -34,7 +34,7 @@ public class Parser {
 
         if (isCommandInput(text, "create")) {
             return prepareCreate(text);
-        } else if (text.startsWith("edit ")) {
+        } else if (isCommandInput(text, "edit")) {
             return prepareEdit(text);
         } else if (text.startsWith("batch ")) {
             return prepareBatch(text);

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -36,11 +36,11 @@ public class Parser {
             return prepareCreate(text);
         } else if (isCommandInput(text, "edit")) {
             return prepareEdit(text);
-        } else if (text.startsWith("batch ")) {
+        } else if (isCommandInput(text, "batch")) {
             return prepareBatch(text);
-        } else if (text.startsWith("withdraw ")) {
+        } else if (isCommandInput(text, "withdraw")) {
             return prepareWithdraw(text);
-        } else if (text.startsWith("delete ")) {
+        } else if (isCommandInput(text, "delete")) {
             return prepareDelete(text);
         } else if (text.equals("list")) {
             return new ListCommand();

--- a/src/test/java/medistock/parser/CreateParserTest.java
+++ b/src/test/java/medistock/parser/CreateParserTest.java
@@ -2,6 +2,7 @@ package medistock.parser;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import medistock.command.Command;
 import medistock.command.CreateCommand;
@@ -32,6 +33,15 @@ public class CreateParserTest {
 
         assertThrows(MediStockException.class,
                 () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_bareCreate_throwsInvalidCreateFormat() {
+        String input = "create";
+
+        MediStockException exception = assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+        assertTrue(exception.getMessage().startsWith("Invalid create format."));
     }
 
     @Test

--- a/src/test/java/medistock/parser/DeleteParserTest.java
+++ b/src/test/java/medistock/parser/DeleteParserTest.java
@@ -2,6 +2,7 @@ package medistock.parser;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import medistock.command.Command;
 import medistock.command.DeleteCommandName;
@@ -33,6 +34,15 @@ public class DeleteParserTest {
 
         assertThrows(MediStockException.class,
                 () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_bareDelete_throwsInvalidDeleteFormat() {
+        String input = "delete";
+
+        MediStockException exception = assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+        assertTrue(exception.getMessage().startsWith("Invalid delete format."));
     }
 
     @Test

--- a/src/test/java/medistock/parser/EditParserTest.java
+++ b/src/test/java/medistock/parser/EditParserTest.java
@@ -2,6 +2,7 @@ package medistock.parser;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import medistock.command.Command;
 import medistock.command.EditCommand;
@@ -48,6 +49,15 @@ public class EditParserTest {
 
         assertThrows(MediStockException.class,
                 () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_bareEdit_throwsInvalidEditFormat() {
+        String input = "edit";
+
+        MediStockException exception = assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+        assertTrue(exception.getMessage().startsWith("Invalid edit format."));
     }
 
     @Test

--- a/src/test/java/medistock/parser/WithdrawParserTest.java
+++ b/src/test/java/medistock/parser/WithdrawParserTest.java
@@ -2,6 +2,7 @@ package medistock.parser;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import medistock.command.Command;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,15 @@ public class WithdrawParserTest {
 
         assertThrows(MediStockException.class,
                 () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_bareWithdraw_throwsInvalidWithdrawFormat() {
+        String input = "withdraw";
+
+        MediStockException exception = assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+        assertTrue(exception.getMessage().startsWith("Invalid withdraw format."));
     }
 
     @Test


### PR DESCRIPTION
Writing a command name without any details returns that the command is unknown. I fixed this by catching this error and outputting the correct command format to guide the user better.