### PR TITLE
Split BatchTests into BatchParserTest and BatchTest

### DIFF
--- a/src/test/java/medistock/inventory/BatchTest.java
+++ b/src/test/java/medistock/inventory/BatchTest.java
@@ -1,7 +1,6 @@
 package medistock.inventory;
 
 import medistock.exception.MediStockException;
-import medistock.parser.Parser;
 import medistock.ui.Ui;
 import org.junit.jupiter.api.Test;
 
@@ -11,43 +10,11 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class BatchTest {
-
-    @Test
-    void prepareBatch_missingNameTag_throwsException() {
-        String input = "batch q/10 d/2025-01-01";
-
-        assertThrows(MediStockException.class,
-                () -> Parser.prepareBatch(input));
-    }
-
-    @Test
-    void prepareBatch_incorrectTagOrder_throwsException() {
-        String input = "batch q/10 n/Vyvanse 40mg d/2025-01-01";
-
-        assertThrows(MediStockException.class,
-                () -> Parser.prepareBatch(input));
-    }
-
-    @Test
-    void prepareBatch_quantityNegative_throwsException() {
-        String input = "batch n/Aspirin q/-5 d/2025-01-01";
-
-        assertThrows(MediStockException.class,
-                () -> Parser.prepareBatch(input));
-    }
-
-    @Test
-    void prepareBatch_validFormat_doesNotThrow() {
-        String input = "batch n/Aspirin q/10 d/2025-01-01";
-
-        assertDoesNotThrow(() -> Parser.prepareBatch(input));
-    }
 
     @Test
     void execute_existingItem_increasesQuantity() throws MediStockException {

--- a/src/test/java/medistock/parser/BatchParserTest.java
+++ b/src/test/java/medistock/parser/BatchParserTest.java
@@ -1,0 +1,41 @@
+package medistock.parser;
+
+import medistock.exception.MediStockException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class BatchParserTest {
+
+    @Test
+    void prepareBatch_missingNameTag_throwsException() {
+        String input = "batch q/10 d/2025-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
+    void prepareBatch_incorrectTagOrder_throwsException() {
+        String input = "batch q/10 n/Vyvanse 40mg d/2025-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
+    void prepareBatch_quantityNegative_throwsException() {
+        String input = "batch n/Aspirin q/-5 d/2025-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
+    void prepareBatch_validFormat_doesNotThrow() {
+        String input = "batch n/Aspirin q/10 d/2025-01-01";
+
+        assertDoesNotThrow(() -> Parser.prepareBatch(input));
+    }
+}

--- a/src/test/java/medistock/parser/BatchParserTest.java
+++ b/src/test/java/medistock/parser/BatchParserTest.java
@@ -5,8 +5,18 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class BatchParserTest {
+
+    @Test
+    void parseCommand_bareBatch_throwsInvalidBatchFormat() {
+        String input = "batch";
+
+        MediStockException exception = assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+        assertTrue(exception.getMessage().startsWith("Invalid batch format."));
+    }
 
     @Test
     void prepareBatch_missingNameTag_throwsException() {


### PR DESCRIPTION
I split the tests for batch command in BatchTest into BatchTest and BatchParserTest. This improves organization since batch's parser tests now sit under parser folder.

We could also rename BatchTest as BatchCommandTest in the future.