### PR TITLE
Reject duplicate prefixes in create and edit parsers

### DIFF
--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -131,6 +131,25 @@ public class Parser {
         return index + 1;
     }
 
+    private static int countPrefixOccurrences(String text, String prefix) {
+        int count = 0;
+        int index = text.indexOf(" " + prefix);
+        while (index != -1) {
+            count++;
+            index = text.indexOf(" " + prefix, index + 1);
+        }
+        return count;
+    }
+
+    private static void rejectDuplicatePrefixes(String text, String errorMessage, String... prefixes)
+            throws MediStockException {
+        for (String prefix : prefixes) {
+            if (countPrefixOccurrences(text, prefix) > 1) {
+                throw new MediStockException(errorMessage);
+            }
+        }
+    }
+
     /**
      * Parses the "batch" command input and prepares a BatchCommand for execution.
      *
@@ -198,6 +217,8 @@ public class Parser {
             throw new MediStockException("Invalid create format. " + Ui.CREATE_FORMAT);
         }
 
+        rejectDuplicatePrefixes(text, "Use create format: " + Ui.CREATE_FORMAT, "n/", "u/", "min/");
+
         if (!(nameIndex < unitIndex && unitIndex < minIndex)) {
             throw new MediStockException("Use create format: " + Ui.CREATE_FORMAT);
         }
@@ -240,6 +261,8 @@ public class Parser {
         if (oldNameIndex == -1) {
             throw new MediStockException("Invalid edit format. " + Ui.EDIT_FORMAT);
         }
+
+        rejectDuplicatePrefixes(text, "Use edit format: " + Ui.EDIT_FORMAT, "o/", "n/", "u/", "min/");
 
         if (nameIndex == -1 && unitIndex == -1 && minIndex == -1) {
             throw new MediStockException("Edit command requires at least one field to update.");

--- a/src/test/java/medistock/parser/CreateParserTest.java
+++ b/src/test/java/medistock/parser/CreateParserTest.java
@@ -69,6 +69,30 @@ public class CreateParserTest {
     }
 
     @Test
+    void parseCommand_duplicateNameTag_throwsException() {
+        String input = "create n/Aspirin n/Panadol u/Tablets min/10";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateUnitTag_throwsException() {
+        String input = "create n/Aspirin u/Tablets u/Capsules min/10";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateMinTag_throwsException() {
+        String input = "create n/Aspirin u/Tablets min/10 min/20";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
     void parseCommand_emptyName_throwsException() {
         String input = "create n/ u/Tablets min/10";
 

--- a/src/test/java/medistock/parser/EditParserTest.java
+++ b/src/test/java/medistock/parser/EditParserTest.java
@@ -123,4 +123,36 @@ public class EditParserTest {
         assertThrows(MediStockException.class,
                 () -> Parser.parseCommand(input));
     }
+
+    @Test
+    void parseCommand_duplicateOldNameTag_throwsException() {
+        String input = "edit o/Aspirin o/Panadol n/Ibuprofen";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateNewNameTag_throwsException() {
+        String input = "edit o/Aspirin n/Panadol n/Ibuprofen";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateUnitTag_throwsException() {
+        String input = "edit o/Aspirin u/Tablets u/Capsules";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateMinTag_throwsException() {
+        String input = "edit o/Aspirin min/10 min/20";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
 }


### PR DESCRIPTION
Fixed duplicate prefixes in create and edit commands
