### PR TITLE
Fix inconsistent jar file name in UG and DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -604,13 +604,13 @@ simplifies stock-taking, and helps maintain minimum stock thresholds so that cri
 
 ## Appendix E: Instructions for Manual Testing
 
-The steps below assume the jar file is named `medistock.jar` and is run from its containing folder.
+The steps below assume the jar file is named `MediStock-v2.1.jar` and is run from its containing folder.
 
 ### Launching the application
 
 1. Ensure that Java 17 or above is installed.
-2. Open a terminal in the folder containing `medistock.jar`.
-3. Run `java -jar medistock.jar`.
+2. Open a terminal in the folder containing `MediStock-v2.1.jar`.
+3. Run `java -jar MediStock-v2.1.jar`.
 
 ### Starting from a clean state
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -12,7 +12,7 @@ when handling routine stock-management tasks.
    Mac users should follow the Java installation guide [here](https://se-education.org/guides/tutorials/javaInstallationMac.html).
 2. Download the latest version of `MediStock` from [here](https://github.com/AY2526S2-CS2113-W10-2/tp/releases).
 3. Open a terminal in the folder containing the downloaded JAR file.
-4. Run `java -jar medistock.jar`.
+4. Run `java -jar MediStock-v2.1.jar`.
 5. Type a command and press Enter.
 
 ## Features


### PR DESCRIPTION
Fixed inconsistent jar file name in the User Guide and Developer Guide.

Closes Issue #161 