### PR TITLE
Add more parser validation for invalid prefixes

### DIFF
--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -159,6 +159,15 @@ public class Parser {
         }
     }
 
+    private static void rejectUnexpectedTextBeforeFirstPrefix(
+            String text, String commandWord, String expectedPrefix, String errorMessage)
+            throws MediStockException {
+        String arguments = text.substring(commandWord.length()).trim();
+        if (!arguments.startsWith(expectedPrefix)) {
+            throw new MediStockException(errorMessage);
+        }
+    }
+
     /**
      * Parses the "batch" command input and prepares a BatchCommand for execution.
      *
@@ -176,9 +185,12 @@ public class Parser {
             throw new MediStockException("Invalid batch format. " + Ui.BATCH_FORMAT);
         }
 
+        String invalidOrderMessage = "Ensure the arguments are in the correct order:" + Ui.BATCH_FORMAT;
+        rejectDuplicatePrefixes(text, invalidOrderMessage, "n/", "q/", "d/");
+        rejectUnexpectedTextBeforeFirstPrefix(text, "batch", "n/", invalidOrderMessage);
+
         if (!(nameIndex < quantIndex && quantIndex < expiryIndex)) {
-            throw new MediStockException("Ensure the arguments are in the correct order:" +
-                            Ui.BATCH_FORMAT);
+            throw new MediStockException(invalidOrderMessage);
         }
 
         String name = getArgument(text, nameIndex, quantIndex).trim();

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -374,8 +374,12 @@ public class Parser {
         if (nameIndex == -1 || quantityIndex == -1) {
             throw new MediStockException("Invalid withdraw format. " + Ui.WITHDRAW_FORMAT);
         }
+        String invalidOrderMessage = "Use correct format: " + Ui.WITHDRAW_FORMAT;
+        rejectDuplicatePrefixes(text, invalidOrderMessage, "n/", "q/");
+        rejectUnexpectedTextBeforeFirstPrefix(text, "withdraw", "n/", invalidOrderMessage);
+
         if (!(nameIndex < quantityIndex)) {
-            throw new MediStockException("Use correct format: " + Ui.WITHDRAW_FORMAT);
+            throw new MediStockException(invalidOrderMessage);
         }
 
         String name = getArgument(text, nameIndex, quantityIndex);

--- a/src/test/java/medistock/parser/BatchParserTest.java
+++ b/src/test/java/medistock/parser/BatchParserTest.java
@@ -35,6 +35,38 @@ public class BatchParserTest {
     }
 
     @Test
+    void prepareBatch_unexpectedTextBeforeNameTag_throwsException() {
+        String input = "batch extra n/Aspirin q/10 d/2025-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
+    void prepareBatch_duplicateNameTag_throwsException() {
+        String input = "batch n/Aspirin n/Panadol q/10 d/2025-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
+    void prepareBatch_duplicateQuantityTag_throwsException() {
+        String input = "batch n/Aspirin q/10 q/20 d/2025-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
+    void prepareBatch_duplicateExpiryDateTag_throwsException() {
+        String input = "batch n/Aspirin q/10 d/2025-01-01 d/2026-01-01";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.prepareBatch(input));
+    }
+
+    @Test
     void prepareBatch_quantityNegative_throwsException() {
         String input = "batch n/Aspirin q/-5 d/2025-01-01";
 

--- a/src/test/java/medistock/parser/WithdrawParserTest.java
+++ b/src/test/java/medistock/parser/WithdrawParserTest.java
@@ -54,6 +54,30 @@ public class WithdrawParserTest {
     }
 
     @Test
+    void parseCommand_unexpectedTextBeforeNameTag_throwsException() {
+        String input = "withdraw extra n/Aspirin q/5";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateNameTag_throwsException() {
+        String input = "withdraw n/Aspirin n/Panadol q/5";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateQuantityTag_throwsException() {
+        String input = "withdraw n/Aspirin q/5 q/10";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
     void parseCommand_nonNumericQuantity_throwsException() {
         String input = "withdraw n/Aspirin q/abc";
 


### PR DESCRIPTION
Reject invalid prefixed commands with duplicate prefixes or unexpected text before the first required prefix. Adds parser tests for batch and withdraw validation paths.