### PR TITLE
Improve parser handling for commands

### DIFF
--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -415,19 +415,22 @@ public class Parser {
     }
 
     private static Command prepareDelete(String text) throws MediStockException {
+        String invalidFormatMessage = "Invalid delete format. " + Ui.DELETE_FORMAT;
         boolean hasNamePrefix = getPrefixedIndex(text, "n/") != -1;
         boolean hasIndexPrefix = getPrefixedIndex(text, "i/") != -1;
 
         if (hasNamePrefix && hasIndexPrefix) {
-            throw new MediStockException("Invalid delete format. " + Ui.DELETE_FORMAT);
+            throw new MediStockException(invalidFormatMessage);
         }
+
+        rejectDuplicatePrefixes(text, invalidFormatMessage, "n/", "i/");
 
         if (text.startsWith("delete n/")) {
             return prepareDeleteName(text);
         } else if (text.startsWith("delete i/")) {
             return prepareDeleteIndex(text);
         }
-        throw new MediStockException("Invalid delete format. " + Ui.DELETE_FORMAT);
+        throw new MediStockException(invalidFormatMessage);
     }
 
     private static Command prepareDeleteName(String text) throws MediStockException {

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -58,8 +58,10 @@ public class Parser {
         } else if (commandWord.equals("delete")) {
             return prepareDelete(text);
         } else if (commandWord.equals("list")) {
+            rejectUnexpectedArguments(text, commandWord, "Use list format: list");
             return new ListCommand();
         } else if (commandWord.equals("history")) {
+            rejectUnexpectedArguments(text, commandWord, "Use history format: history");
             return new HistoryCommand();
         } else if (commandWord.equals("exit") || commandWord.equals("quit")) {
             return new ExitCommand();
@@ -164,6 +166,14 @@ public class Parser {
             throws MediStockException {
         String arguments = text.substring(commandWord.length()).trim();
         if (!arguments.startsWith(expectedPrefix)) {
+            throw new MediStockException(errorMessage);
+        }
+    }
+
+    private static void rejectUnexpectedArguments(String text, String commandWord, String errorMessage)
+            throws MediStockException {
+        String arguments = text.substring(commandWord.length()).trim();
+        if (!arguments.isEmpty()) {
             throw new MediStockException(errorMessage);
         }
     }

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -415,6 +415,13 @@ public class Parser {
     }
 
     private static Command prepareDelete(String text) throws MediStockException {
+        boolean hasNamePrefix = getPrefixedIndex(text, "n/") != -1;
+        boolean hasIndexPrefix = getPrefixedIndex(text, "i/") != -1;
+
+        if (hasNamePrefix && hasIndexPrefix) {
+            throw new MediStockException("Invalid delete format. " + Ui.DELETE_FORMAT);
+        }
+
         if (text.startsWith("delete n/")) {
             return prepareDeleteName(text);
         } else if (text.startsWith("delete i/")) {

--- a/src/main/java/medistock/parser/Parser.java
+++ b/src/main/java/medistock/parser/Parser.java
@@ -58,10 +58,11 @@ public class Parser {
         } else if (commandWord.equals("delete")) {
             return prepareDelete(text);
         } else if (commandWord.equals("list")) {
-            rejectUnexpectedArguments(text, commandWord, "Use list format: list");
+            rejectUnexpectedArguments(text, commandWord, "The list command does not take any arguments. Format: list");
             return new ListCommand();
         } else if (commandWord.equals("history")) {
-            rejectUnexpectedArguments(text, commandWord, "Use history format: history");
+            rejectUnexpectedArguments(text, commandWord,
+                    "The history command does not take any arguments. Format: history");
             return new HistoryCommand();
         } else if (commandWord.equals("exit") || commandWord.equals("quit")) {
             return new ExitCommand();

--- a/src/test/java/medistock/parser/DeleteParserTest.java
+++ b/src/test/java/medistock/parser/DeleteParserTest.java
@@ -53,6 +53,22 @@ public class DeleteParserTest {
     }
 
     @Test
+    void parseCommand_duplicateNameTag_throwsException() {
+        String input = "delete n/Aspirin n/Panadol";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_duplicateIndexTag_throwsException() {
+        String input = "delete i/1 i/2";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
     void parseCommand_bareDelete_throwsInvalidDeleteFormat() {
         String input = "delete";
 

--- a/src/test/java/medistock/parser/DeleteParserTest.java
+++ b/src/test/java/medistock/parser/DeleteParserTest.java
@@ -37,6 +37,22 @@ public class DeleteParserTest {
     }
 
     @Test
+    void parseCommand_nameThenIndexTag_throwsException() {
+        String input = "delete n/Aspirin i/1";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
+    void parseCommand_indexThenNameTag_throwsException() {
+        String input = "delete i/1 n/Aspirin";
+
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand(input));
+    }
+
+    @Test
     void parseCommand_bareDelete_throwsInvalidDeleteFormat() {
         String input = "delete";
 

--- a/src/test/java/medistock/parser/NoArgumentParserTest.java
+++ b/src/test/java/medistock/parser/NoArgumentParserTest.java
@@ -1,0 +1,39 @@
+package medistock.parser;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import medistock.command.Command;
+import medistock.command.HistoryCommand;
+import medistock.command.ListCommand;
+import medistock.exception.MediStockException;
+import org.junit.jupiter.api.Test;
+
+public class NoArgumentParserTest {
+
+    @Test
+    void parseCommand_validList_returnsListCommand() throws MediStockException {
+        Command command = Parser.parseCommand("list");
+
+        assertInstanceOf(ListCommand.class, command);
+    }
+
+    @Test
+    void parseCommand_listWithArguments_throwsException() {
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand("list aspirin"));
+    }
+
+    @Test
+    void parseCommand_validHistory_returnsHistoryCommand() throws MediStockException {
+        Command command = Parser.parseCommand("history");
+
+        assertInstanceOf(HistoryCommand.class, command);
+    }
+
+    @Test
+    void parseCommand_historyWithArguments_throwsException() {
+        assertThrows(MediStockException.class,
+                () -> Parser.parseCommand("history all"));
+    }
+}


### PR DESCRIPTION
Rejects extra arguments for no-argument commands and invalid delete prefix combinations. Adds parser tests for malformed list, history, and delete inputs.